### PR TITLE
fix:解决amap3d无法自定义mapView宽高的问题

### DIFF
--- a/harmony/rn_amap3d/src/main/ets/View/MapView.ets
+++ b/harmony/rn_amap3d/src/main/ets/View/MapView.ets
@@ -53,7 +53,6 @@ export const GOADE_MAP_VIEW_TYPE: string = "AMapView"
 
 export type GDMapViewDescriptor = Descriptor<"AMapView", MapViewProps>;
 
-@Entry
 @Component
 export struct AMapView {
   static NAME: string = "AMapView";
@@ -478,10 +477,8 @@ export struct AMapView {
   }
 
   build() {
-    Column() {
+    RNViewBase({ ctx: this.ctx, tag: this.tag }){
       MapViewComponent().width('100%').height('100%')
     }
-    .height(1700)
-    .width("100%")
   }
 }


### PR DESCRIPTION
# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- 解决amap3d无法自定义mapView宽高的问题
- closed：#37

## Test Plan
在amap3d的demo中设置amap3d的mapview宽高
<MapView
style={{ width: '100%', height: '50%' }}
最终显示效果view展示一半
![image](https://github.com/user-attachments/assets/a5527e38-1316-49f5-b50c-e7843ac622fa)


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
