### PR TITLE
fix: 修改地图跳转一级之后在返回地图点击marker只生效一次问题

### DIFF
--- a/harmony/rn_amap3d/src/main/ets/View/MapView.ets
+++ b/harmony/rn_amap3d/src/main/ets/View/MapView.ets
@@ -568,6 +568,7 @@ export struct AMapView {
                     marker.setDraggable(mapMarkerProps.draggable ? mapMarkerProps.draggable : false);
                     marker.setZIndex(mapMarkerProps.zIndex ? mapMarkerProps.zIndex : 1);
                     marker.setFlat(mapMarkerProps.flat ? mapMarkerProps.flat : false);
+                    mapMarker.set(AMapView.num, markers);
                   }
                 }
               } catch (error) {
@@ -579,7 +580,6 @@ export struct AMapView {
       }
       flag = false;
     }
-    mapMarker.set(AMapView.num, markers);
   }
 
   aboutToDisappear(): void {


### PR DESCRIPTION
# Summary

fix: 修改地图跳转一级之后在返回地图点击marker只生效一次问题

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)