### PR TITLE
fix: 修改跳转3级及以上界面返回时地图为空的情况，修改覆盖物创建方式

### DIFF
--- a/harmony/rn_amap3d/src/main/ets/GlobalCache.ets
+++ b/harmony/rn_amap3d/src/main/ets/GlobalCache.ets
@@ -1,0 +1,19 @@
+import {
+    AMap, MapView, Marker, Polyline
+} from '@amap/amap_lbs_map3d';
+import HashMap from '@ohos.util.HashMap';
+
+export default class GlobalCache {
+  public static index: number = 1
+  public static isGO: boolean = false;
+  public static cacheMap: Map<Object | undefined, number> = new Map()
+  public static cacheMapPageDestroy: Map<number, boolean> = new Map()
+  public static mapMarker: Map<number, Array<Marker>> = new Map();
+  public static mapPolyLine: Map<number, Array<Polyline>> = new Map();
+  public static markers: Array<Marker> = new Array();
+  public static polyLines: Array<Polyline> = new Array();
+  public static mapViews: HashMap<number, MapView> = new HashMap();
+  public static maps: HashMap<number, AMap> = new HashMap();
+  public static currentPageMarker: HashMap<number, number> = new HashMap();
+  public static currentPagePolyline: HashMap<number, number> = new HashMap();
+}

--- a/harmony/rn_amap3d/src/main/ets/Logger.ets
+++ b/harmony/rn_amap3d/src/main/ets/Logger.ets
@@ -30,6 +30,7 @@ class Logger {
   private format : string = '%{public}s, %{public}s';
   private isDebug : boolean;
 
+
   /**
    * constructor.
    *

--- a/harmony/rn_amap3d/src/main/ets/View/AMapCircle.ets
+++ b/harmony/rn_amap3d/src/main/ets/View/AMapCircle.ets
@@ -26,7 +26,6 @@ export interface AMapCircleProps extends ViewBaseProps {
 export const A_MAP_CIRCLE_VIEW_TYPE: string = "AMapCircle";
 
 export type AMapCircleDescriptor = Descriptor<"AMapCircle", AMapCircleProps>
-@Entry
 @Component
 export struct AMapCircle {
   static NAME:string = "AMapCircle";

--- a/harmony/rn_amap3d/src/main/ets/View/AMapMarker.ets
+++ b/harmony/rn_amap3d/src/main/ets/View/AMapMarker.ets
@@ -1,6 +1,7 @@
 import { BitmapDescriptor, BitmapDescriptorFactory, LatLng, Marker, Point } from '@amap/amap_lbs_map3d';
 import { Descriptor, RNOHContext, ViewBaseProps } from '@rnoh/react-native-openharmony';
-import { AMapView, globalContext, mapMarker } from './MapView';
+import { globalContext } from './MapView';
+import GlobalCache from '../GlobalCache';
 
 export interface AMapMarkerProps extends ViewBaseProps {
   position: LatLng;
@@ -17,7 +18,6 @@ export const A_MAP_MARKER_TYPE: string = "AMapMarker";
 
 export type AMapMarkerDescriptor = Descriptor<"AMapMarker", AMapMarkerProps>;
 
-@Entry
 @Component
 export struct AMapMarker {
   ctx !: RNOHContext
@@ -31,7 +31,8 @@ export struct AMapMarker {
     this.unregisterDescriptorChangesListener = this.ctx.descriptorRegistry.subscribeToDescriptorChanges(this.tag,
       async (newDescriptor) => {
         /*------ 当RN侧属性props有更改 -------*/
-        this.markers = mapMarker.get(AMapView.num);
+        let currentPageTag = GlobalCache.currentPageMarker.get(this.tag)
+        this.markers = GlobalCache.mapMarker.get(currentPageTag);
         this.amapDescriptor = (newDescriptor as AMapMarkerDescriptor)
         let mapMarkerProps = this.amapDescriptor.props as AMapMarkerProps;
         if (this.markers) {
@@ -43,6 +44,8 @@ export struct AMapMarker {
               this.markers[i].setDraggable(mapMarkerProps.draggable ? mapMarkerProps.draggable : false);
               this.markers[i].setZIndex(mapMarkerProps.zIndex ? mapMarkerProps.zIndex : 1);
               this.markers[i].setFlat(mapMarkerProps.flat ? mapMarkerProps.flat : false);
+              this.markers[i].getOptions().setInfoWindowOffset(mapMarkerProps.centerOffset?.x,mapMarkerProps.centerOffset?.y);
+              this.markers[i].setMarkerOptions(this.markers[i][i].getOptions());
               if (mapMarkerProps.icon) {
                 try {
                   let resoure: string = mapMarkerProps.icon["uri"];

--- a/harmony/rn_amap3d/src/main/ets/View/AMapPolygon.ets
+++ b/harmony/rn_amap3d/src/main/ets/View/AMapPolygon.ets
@@ -11,7 +11,6 @@ export interface AMapPolygonProps extends ViewBaseProps {
 
 export const A_MAP_POLYGON_TYPE: string = "AMapPolygon";
 export type AMapPolygonDescriptor = Descriptor<"AMapPolygon", AMapPolygonProps>
-@Entry
 @Component
 export struct AMapPolygon {
   ctx !: RNOHContext

--- a/harmony/rn_amap3d/src/main/ets/View/AMapPolyline.ets
+++ b/harmony/rn_amap3d/src/main/ets/View/AMapPolyline.ets
@@ -1,5 +1,8 @@
-import { LatLng, } from '@amap/amap_lbs_map3d';
+import { LatLng, Polyline, } from '@amap/amap_lbs_map3d';
 import { Descriptor, RNOHContext, ViewBaseProps } from '@rnoh/react-native-openharmony';
+import GlobalCache from '../GlobalCache';
+import { ArrayList } from '@kit.ArkTS';
+import { rgbaToHex } from './AMapCircle';
 
 export interface AMapPolylineProps extends ViewBaseProps {
   points: LatLng[];
@@ -25,14 +28,49 @@ export type AMapPolylineDescriptor = Descriptor<"AMapPolyline", AMapPolylineProp
 export struct AMapPolyline {
   ctx !: RNOHContext
   tag: number = -1
+  polyLines: Array<Polyline> | undefined = []
   @State amapDescriptor: AMapPolylineDescriptor = {} as AMapPolylineDescriptor
   static NAME: string = "AMapPolyline";
+  private unregisterDescriptorChangesListener?: () => void = undefined
 
-  onPolyLineClickFunction():void {
-    console.info("AMapViewEventType polyline   =====" + this.tag);
-    this.ctx.rnInstance.emitComponentEvent(this.tag, A_MAP_POLYLINE_TYPE, {
-      type: 'onPress'
-    })
+  aboutToAppear(): void {
+    this.unregisterDescriptorChangesListener = this.ctx.descriptorRegistry.subscribeToDescriptorChanges(this.tag,
+      async (newDescriptor) => {
+        /*------ 当RN侧属性props有更改 -------*/
+        let currentPageTag = GlobalCache.currentPagePolyline.get(this.tag)
+        this.polyLines = GlobalCache.mapPolyLine.get(currentPageTag);
+        this.amapDescriptor = (newDescriptor as AMapPolylineDescriptor)
+        let mapPolylineProp = this.amapDescriptor.props as AMapPolylineProps;
+        if (this.polyLines) {
+          for (let i = 0; i < this.polyLines.length; ++i) {
+            this.polyLines[i].setZIndex(mapPolylineProp.zIndex ? mapPolylineProp.zIndex : 1);
+            this.polyLines[i].setDottedLine(mapPolylineProp.dotted ? mapPolylineProp.dotted : false);
+            this.polyLines[i].setGeodesic(mapPolylineProp.geodesic ? mapPolylineProp.geodesic : false);
+            this.polyLines[i].setWidth(mapPolylineProp.width ? mapPolylineProp.width : 5);
+            let polylineOptionsList = new ArrayList<LatLng>()
+            for (let index = 0; index < mapPolylineProp.points.length; index++) {
+              polylineOptionsList.add(new LatLng(mapPolylineProp.points[index].latitude,
+                mapPolylineProp.points[index].longitude))
+            }
+            this.polyLines[i].setPoints(polylineOptionsList);
+            if (mapPolylineProp.color) {
+              this.polyLines[i].setColor(rgbaToHex(mapPolylineProp.color ? mapPolylineProp.color :
+                "rgba(0, 255, 0, 0.5)"));
+            }
+            if (mapPolylineProp.colors) {
+              let test = new Int32Array(mapPolylineProp.colors.length)
+              for (let i = 0; i < mapPolylineProp.colors.length; ++i) {
+                let str = mapPolylineProp.colors[i].replace("#", "0xff")
+                test[i] = parseInt(str.substring(2, str.length), 16)
+              }
+              this.polyLines[i].getOptions().setColorValues(test);
+              this.polyLines[i].getOptions().setGradient(mapPolylineProp.gradient ? mapPolylineProp.gradient : false);
+              this.polyLines[i].setOptions(this.polyLines[i].getOptions());
+            }
+          }
+        }
+      }
+    )
   }
 
   build() {

--- a/harmony/rn_amap3d/src/main/ets/View/MapView.ets
+++ b/harmony/rn_amap3d/src/main/ets/View/MapView.ets
@@ -1,22 +1,22 @@
 import {
-    AMap,
-    BitmapDescriptor,
-    BitmapDescriptorFactory,
-    CameraPosition,
-    CameraUpdateFactory,
-    CircleOptions,
-    LatLng,
-    MapView,
-    MapViewComponent,
-    MapViewManager,
-    Marker,
-    MarkerOptions,
-    OnCameraChangeListener,
-    OnMarkerDragListener,
-    Poi,
-    PolygonOptions,
-    Polyline,
-    PolylineOptions
+  AMap,
+  BitmapDescriptor,
+  BitmapDescriptorFactory,
+  CameraPosition,
+  CameraUpdateFactory,
+  CircleOptions,
+  LatLng,
+  MapView,
+  MapViewComponent,
+  MapViewManager,
+  Marker,
+  MarkerOptions,
+  OnCameraChangeListener,
+  OnMarkerDragListener,
+  Poi,
+  PolygonOptions,
+  Polyline,
+  PolylineOptions
 } from '@amap/amap_lbs_map3d';
 
 import { Descriptor, RNOHContext, RNViewBase, ViewBaseProps } from '@rnoh/react-native-openharmony';
@@ -27,6 +27,7 @@ import { A_MAP_MARKER_TYPE, AMapMarkerProps } from './AMapMarker';
 
 import Logger from '../Logger';
 import { ArrayList } from '@kit.ArkTS';
+import GlobalCache from '../GlobalCache';
 
 export interface MapViewProps extends ViewBaseProps {
   initialCameraPosition?: CameraPosition;
@@ -58,10 +59,6 @@ export type GDMapViewDescriptor = Descriptor<"AMapView", MapViewProps>;
 
 export let globalContext: Context;
 
-export let markers: Array<Marker>
-
-export let mapMarker: Map<number, Array<Marker>> = new Map();
-
 @Component
 export struct AMapView {
   static NAME: string = "AMapView";
@@ -74,28 +71,8 @@ export struct AMapView {
   @State gDMapDescriptor: GDMapViewDescriptor = {} as GDMapViewDescriptor
   private unregisterDescriptorChangesListener?: () => void = undefined
   private cleanupCallback?: () => void = undefined;
-  //覆盖物
-  circleOption: Array<CircleOptions> = []
-  polylineOption: Array<PolylineOptions> = []
-  polygonOption: Array<PolygonOptions> = []
 
   aboutToAppear(): void {
-    globalContext = getContext().getApplicationContext();
-    this.gDMapDescriptor = this.ctx.descriptorRegistry.getDescriptor<GDMapViewDescriptor>(this.tag);
-    markers = [];
-    this.getProp(this.gDMapDescriptor);
-    AMapView.num++;
-    this.show();
-    this.unregisterDescriptorChangesListener = this.ctx.descriptorRegistry.subscribeToDescriptorChanges(this.tag,
-      (newDescriptor) => {
-        /*------ 当RN侧属性props有更改 -------*/
-        console.log(`RNOH in GaoDeMap descriptor change`);
-        this.gDMapDescriptor = (newDescriptor as GDMapViewDescriptor)
-        this.getProp(this.gDMapDescriptor);
-        this.getOverlay(this.gDMapDescriptor);
-      }
-    )
-
     this.cleanupCallback = this.ctx.componentCommandReceiver.registerCommandCallback(
       this.tag,
       (command, args: ESObject[]) => {
@@ -103,6 +80,31 @@ export struct AMapView {
           this.aMap?.animateCamera(CameraUpdateFactory.newCameraPosition(args[0]), null, args[1]);
         }
       });
+    globalContext = getContext().getApplicationContext();
+    this.gDMapDescriptor = this.ctx.descriptorRegistry.getDescriptor<GDMapViewDescriptor>(this.tag);
+    GlobalCache.markers = [];
+    this.getProp(this.gDMapDescriptor);
+    this.show();
+    this.unregisterDescriptorChangesListener = this.ctx.descriptorRegistry.subscribeToDescriptorChanges(this.tag,
+      (newDescriptor) => {
+        /*------ 当RN侧属性props有更改 -------*/
+        this.gDMapDescriptor = (newDescriptor as GDMapViewDescriptor)
+        this.getProp(this.gDMapDescriptor);
+        this.getOverlay(this.gDMapDescriptor);
+      }
+    )
+  }
+
+  aboutToDisappear(): void {
+    if (this.mapViewCreateCallback) {
+      MapViewManager.getInstance().unregisterMapViewCreatedCallback(this.mapViewCreateCallback);
+    }
+    this.unregisterDescriptorChangesListener?.()
+    this.cleanupCallback?.()
+    GlobalCache.maps.get(this.tag)?.clear()
+    GlobalCache.mapViews.get(this.tag)?.onDestroy();
+    GlobalCache.mapMarker.delete(this.tag);
+    GlobalCache.mapPolyLine.delete(this.tag);
   }
 
   //地图
@@ -214,13 +216,13 @@ export struct AMapView {
     if (!mapview) {
       return;
     }
-    this.mapView = mapview;
+    GlobalCache.mapViews.set(this.tag, mapview);
+    this.mapView = GlobalCache.mapViews.get(this.tag);
     this.mapView.onCreate();
-
-    this.mapView.getMapAsync((map) => {
-      this.aMap = map;
+    this.mapView.getMapAsync((map:AMap) => {
+      GlobalCache.maps.set(this.tag, map);
+      this.aMap = GlobalCache.maps.get(this.tag);
       this.getOverlay(this.gDMapDescriptor);
-      Logger.info('map3d', 'EntryAbility', 'get map ' + this.aMap?.getCameraPosition()?.zoom);
       if (this.initialCameraPosition != null) {
         this.aMap?.moveCamera(CameraUpdateFactory.newCameraPosition(this.initialCameraPosition));
       }
@@ -247,60 +249,45 @@ export struct AMapView {
         `getMapContentApprovalNumber ${approvalNumber} satelliteImageApprovalNumber ${satelliteImageApprovalNumber}`);
 
       //地图属性
-      {
-        this.aMap.setMapType(this.mapType);
-        this.aMap.setTrafficEnabled(this.trafficEnabled);
-        //设置地图最大缩放级别 缩放级别范围为[3, 20],超出范围将按最大级别计算 。
-        // 注：只有在有室内地图显示的情况下最大级别为20，否则最大级别为19。
-        this.aMap.setMinZoomLevel(this.minZoom);
-        this.aMap.setMaxZoomLevel(this.maxZoom);
-        this.aMap.setMyLocationEnabled(this.myLocationEnabled);
-        //设置最小缩放级别 缩放级别范围为[3, 20],超出范围将按最小级别计算
-        this.aMap.showBuildings(this.buildingsEnabled);
-        this.aMap.showMapText(this.labelsEnabled);
-        let uiSettings = this.aMap?.getUiSettings();
-        uiSettings?.setZoomGesturesEnabled(this.zoomGesturesEnabled);
-        uiSettings?.setScrollGesturesEnabled(this.scrollGesturesEnabled);
-        uiSettings?.setRotateGesturesEnabled(this.rotateGesturesEnabled);
-        uiSettings?.setTiltGesturesEnabled(this.tiltGesturesEnabled);
-        uiSettings?.setScaleControlsEnabled(this.scaleControlsEnabled);
-        uiSettings?.setCompassEnabled(this.compassEnabled);
-        uiSettings?.setMyLocationButtonEnabled(this.myLocationButtonEnabled);
-        uiSettings?.setZoomControlsEnabled(this.zoomControlsEnabled);
-      }
+
+      this.aMap.setMapType(this.mapType);
+      this.aMap.setTrafficEnabled(this.trafficEnabled);
+      //设置地图最大缩放级别 缩放级别范围为[3, 20],超出范围将按最大级别计算 。
+      // 注：只有在有室内地图显示的情况下最大级别为20，否则最大级别为19。
+      this.aMap.setMinZoomLevel(this.minZoom);
+      this.aMap.setMaxZoomLevel(this.maxZoom);
+      this.aMap.setMyLocationEnabled(this.myLocationEnabled);
+      //设置最小缩放级别 缩放级别范围为[3, 20],超出范围将按最小级别计算
+      this.aMap.showBuildings(this.buildingsEnabled);
+      this.aMap.showMapText(this.labelsEnabled);
+      let uiSettings = this.aMap?.getUiSettings();
+      uiSettings?.setZoomGesturesEnabled(this.zoomGesturesEnabled);
+      uiSettings?.setScrollGesturesEnabled(this.scrollGesturesEnabled);
+      uiSettings?.setRotateGesturesEnabled(this.rotateGesturesEnabled);
+      uiSettings?.setTiltGesturesEnabled(this.tiltGesturesEnabled);
+      uiSettings?.setScaleControlsEnabled(this.scaleControlsEnabled);
+      uiSettings?.setCompassEnabled(this.compassEnabled);
+      uiSettings?.setMyLocationButtonEnabled(this.myLocationButtonEnabled);
+      uiSettings?.setZoomControlsEnabled(this.zoomControlsEnabled);
 
       this.onLoadFunction();
 
-      for (let index = 0; index < this.circleOption.length; ++index) {
-        if (this.circleOption[index] && this.circleOption[index].getRadius()) {
-          this.aMap?.addCircle(this.circleOption[index])
-        }
-      }
-
-      for (let index = 0; index < this.polygonOption.length; ++index) {
-        if (this.polygonOption[index] && this.polygonOption[index].getPoints().length > 0) {
-          this.aMap?.addPolygon(this.polygonOption[index]);
-        }
-      }
-
-      for (let index = 0; index < this.polylineOption.length; ++index) {
-        if (this.polylineOption[index] && this.polylineOption[index].getPoints().length > 0) {
-          this.aMap?.addPolyline(this.polylineOption[index]);
-        }
-      }
-
       this.aMap?.setOnPolylineClickListener((polyLine: Polyline): void => {
-        for (let index = 0; index < this.polylineOption.length; ++index) {
-          if (polyLine.getOptions() == this.polylineOption[index]) {
-            this.onPolyLineClickFunction(index)
+        let len: number | undefined = GlobalCache.mapPolyLine.get(this.tag)?.length;
+        let polyline: Array<Polyline> | undefined = GlobalCache.mapPolyLine.get(this.tag);
+        if (len && polyline) {
+          for (let index = 0; index < len; ++index) {
+            if (polyLine.getOptions() == polyline[index].getOptions()) {
+              this.onPolyLineClickFunction(index)
+            }
           }
         }
       });
 
       this.aMap?.setOnMarkerClickListener((marker: Marker): boolean => {
-        if (mapMarker.get(AMapView.num)) {
-          let len: number | undefined = mapMarker.get(AMapView.num)?.length;
-          let markers: Array<Marker> | undefined = mapMarker.get(AMapView.num);
+        if (GlobalCache.mapMarker.get(this.tag)) {
+          let len: number | undefined = GlobalCache.mapMarker.get(this.tag)?.length;
+          let markers: Array<Marker> | undefined = GlobalCache.mapMarker.get(this.tag);
           if (len && markers) {
             for (let index = 0; index < len; ++index) {
               if (marker.getOptions().getPosition() == markers[index].getPosition()) {
@@ -314,36 +301,36 @@ export struct AMapView {
 
       this.aMap?.setOnMarkerDragListener(new OnMarkerDragListener(
         (DragStart: Marker) => {
-          for (let index = 0; index < markers.length; ++index) {
-            if (mapMarker.get(AMapView.num)) {
-              let len: number | undefined = mapMarker.get(AMapView.num)?.length;
-              let markers: Array<Marker> | undefined = mapMarker.get(AMapView.num);
+          let len: number | undefined = GlobalCache.mapMarker.get(this.tag)?.length;
+          let markers: Array<Marker> | undefined = GlobalCache.mapMarker.get(this.tag);
+          if (len && markers) {
+            for (let index = 0; index < len; ++index) {
               if (len && markers) {
                 if (DragStart == markers[index]) {
-                  this.onMarkerDragStartFunction(index)
+                  this.onMarkerDragStartFunction(index);
                 }
               }
             }
           }
         },
         (Drag: Marker) => {
-          for (let index = 0; index < markers.length; ++index) {
-            if (mapMarker.get(AMapView.num)) {
-              let len: number | undefined = mapMarker.get(AMapView.num)?.length;
-              let markers: Array<Marker> | undefined = mapMarker.get(AMapView.num);
+          let len: number | undefined = GlobalCache.mapMarker.get(this.tag)?.length;
+          let markers: Array<Marker> | undefined = GlobalCache.mapMarker.get(this.tag);
+          if (len && markers) {
+            for (let index = 0; index < len; ++index) {
               if (len && markers) {
                 if (Drag == markers[index]) {
-                  this.onMarkerDragFunction(index)
+                  this.onMarkerDragFunction(index);
                 }
               }
             }
           }
         },
         (DragEnd: Marker) => {
-          for (let index = 0; index < markers.length; ++index) {
-            if (mapMarker.get(AMapView.num)) {
-              let len: number | undefined = mapMarker.get(AMapView.num)?.length;
-              let markers: Array<Marker> | undefined = mapMarker.get(AMapView.num);
+          let len: number | undefined = GlobalCache.mapMarker.get(this.tag)?.length;
+          let markers: Array<Marker> | undefined = GlobalCache.mapMarker.get(this.tag);
+          if (len && markers) {
+            for (let index = 0; index < len; ++index) {
               if (len && markers) {
                 if (DragEnd == markers[index]) {
                   this.onMarkerDragEndFunction(DragEnd.getPosition(), index)
@@ -442,6 +429,7 @@ export struct AMapView {
   private async getOverlay(descriptor: GDMapViewDescriptor) {
     let tagName = "";
     let flag = false;
+    let flagLine = false;
     for (let i = 0; i < descriptor.childrenTags.length; i++) {
       tagName =
         this.ctx.rnInstance.getComponentNameFromDescriptorType(this.ctx.descriptorRegistry.getDescriptor(descriptor.childrenTags[i])?.type);
@@ -450,74 +438,134 @@ export struct AMapView {
           let circleOptions = new CircleOptions();
           let circleProp =
             this.ctx.descriptorRegistry.getDescriptor(descriptor.childrenTags[i]).props as AMapCircleProps;
-          circleOptions.setRadius(circleProp.radius ? circleProp.radius : 5000);
-          circleOptions.setCenter(new LatLng(circleProp.center.latitude, circleProp.center.longitude));
-          circleOptions.setFillColor(rgbaToHex(circleProp.fillColor ? circleProp.fillColor : "rgba(255, 0, 0, 0.5)"));
-          circleOptions.setStrokeColor(rgbaToHex(circleProp.strokeColor ? circleProp.strokeColor :
-            "rgba(0, 0, 255, 0.5)"));
-          circleOptions.setStrokeWidth(circleProp.strokeWidth ? circleProp.strokeWidth : 5);
-          this.circleOption.push(circleOptions);
+          let circle = this.aMap?.addCircle(circleOptions);
+          if (circle) {
+            circle.setRadius(circleProp.radius ? circleProp.radius : 5000);
+            circle.setCenter(new LatLng(circleProp.center.latitude, circleProp.center.longitude));
+            circle.setFillColor(rgbaToHex(circleProp.fillColor ? circleProp.fillColor : "rgba(255, 0, 0, 0.5)"));
+            circle.setStrokeColor(rgbaToHex(circleProp.strokeColor ? circleProp.strokeColor :
+              "rgba(0, 0, 255, 0.5)"));
+            circle.setStrokeWidth(circleProp.strokeWidth ? circleProp.strokeWidth : 5);
+          }
           break;
         case A_MAP_POLYGON_TYPE:
           let polygonOptions = new PolygonOptions()
+          let polygon = this.aMap?.addPolygon(polygonOptions);
           let mapPolygonProp =
             this.ctx.descriptorRegistry.getDescriptor(descriptor.childrenTags[i]).props as AMapPolygonProps;
-          for (let index = 0; index < mapPolygonProp.points.length; index++) {
-            polygonOptions.add(new LatLng(mapPolygonProp.points[index].latitude,
-              mapPolygonProp.points[index].longitude))
+          if (polygon) {
+            let polygonOptionsList = new ArrayList<LatLng>()
+            for (let index = 0; index < mapPolygonProp.points.length; index++) {
+              polygonOptionsList.add(new LatLng(mapPolygonProp.points[index].latitude,
+                mapPolygonProp.points[index].longitude))
+            }
+            polygon.setPoints(polygonOptionsList);
+            polygon.setFillColor(rgbaToHex(mapPolygonProp.fillColor ? mapPolygonProp.fillColor :
+              "rgba(255, 0, 0, 0.5)"));
+            polygon.setStrokeWidth(mapPolygonProp.strokeWidth ? mapPolygonProp.strokeWidth : 5);
+            polygon.setStrokeColor(rgbaToHex(mapPolygonProp.strokeColor ? mapPolygonProp.strokeColor :
+              "rgba(255, 0, 0, 0.5)"));
+            polygon.setZIndex(mapPolygonProp.zIndex ? mapPolygonProp.zIndex : 2);
           }
-          polygonOptions.setFillColor(rgbaToHex(mapPolygonProp.fillColor ? mapPolygonProp.fillColor :
-            "rgba(255, 0, 0, 0.5)"));
-          polygonOptions.setStrokeWidth(mapPolygonProp.strokeWidth ? mapPolygonProp.strokeWidth : 5);
-          polygonOptions.setStrokeColor(rgbaToHex(mapPolygonProp.strokeColor ? mapPolygonProp.strokeColor :
-            "rgba(255, 0, 0, 0.5)"));
-          polygonOptions.setZIndex(mapPolygonProp.zIndex ? mapPolygonProp.zIndex : 2);
-          this.polygonOption.push(polygonOptions);
           break;
         case A_MAP_POLYLINE_TYPE:
-          // add polyline
-          let polylineOptions = new PolylineOptions();
-          this.polyLineTag.push(this.ctx.descriptorRegistry.getDescriptor(descriptor.childrenTags[i]).tag);
           let mapPolylineProp =
             this.ctx.descriptorRegistry.getDescriptor(descriptor.childrenTags[i]).props as AMapPolylineProps;
-          polylineOptions.setZIndex(mapPolylineProp.zIndex ? mapPolylineProp.zIndex : 1);
-          polylineOptions.setDottedLine(mapPolylineProp.dotted ? mapPolylineProp.dotted : false);
-          polylineOptions.setGeodesic(mapPolylineProp.geodesic ? mapPolylineProp.geodesic : false);
-          polylineOptions.setWidth(mapPolylineProp.width ? mapPolylineProp.width : 5);
-          let polygonOptionsList = new ArrayList<LatLng>()
-          for (let index = 0; index < mapPolylineProp.points.length; index++) {
-            polygonOptionsList.add(new LatLng(mapPolylineProp.points[index].latitude,
-              mapPolylineProp.points[index].longitude))
-          }
-          polylineOptions.setPoints(polygonOptionsList);
-          if (mapPolylineProp.color) {
-            polylineOptions.setColor(rgbaToHex(mapPolylineProp.color ? mapPolylineProp.color :
-              "rgba(0, 255, 0, 0.5)"));
-          }
-          if (mapPolylineProp.colors) {
-            let test = new Int32Array(mapPolylineProp.colors.length)
-            for (let i = 0; i < mapPolylineProp.colors.length; ++i) {
-              let str = mapPolylineProp.colors[i].replace("#", "0xff")
-              test[i] = parseInt(str.substring(2, str.length), 16)
+          let polyLines = (GlobalCache.mapPolyLine.get(this.tag) ?? []);
+          for (let i = 0; i < (GlobalCache.mapPolyLine.get(this.tag) ?? []).length; ++i) {
+            let polylineOptionsList = new ArrayList<LatLng>()
+            for (let index = 0; index < mapPolylineProp.points.length; index++) {
+              polylineOptionsList.add(new LatLng(mapPolylineProp.points[index].latitude,
+                mapPolylineProp.points[index].longitude))
             }
-            polylineOptions.setColorValues(test);
-            polylineOptions.setGradient(mapPolylineProp.gradient ? mapPolylineProp.gradient : false);
+            if (polylineOptionsList == polyLines[i].getPoints()) {
+              flagLine = true;
+              polyLines[i].setZIndex(mapPolylineProp.zIndex ? mapPolylineProp.zIndex : 1);
+              polyLines[i].setDottedLine(mapPolylineProp.dotted ? mapPolylineProp.dotted : false);
+              polyLines[i].setGeodesic(mapPolylineProp.geodesic ? mapPolylineProp.geodesic : false);
+              polyLines[i].setWidth(mapPolylineProp.width ? mapPolylineProp.width : 5);
+              if (mapPolylineProp.color) {
+                polyLines[i].setColor(rgbaToHex(mapPolylineProp.color ? mapPolylineProp.color :
+                  "rgba(0, 255, 0, 0.5)"));
+              }
+              if (mapPolylineProp.colors) {
+                let test = new Int32Array(mapPolylineProp.colors.length)
+                for (let i = 0; i < mapPolylineProp.colors.length; ++i) {
+                  let str = mapPolylineProp.colors[i].replace("#", "0xff")
+                  test[i] = parseInt(str.substring(2, str.length), 16)
+                }
+              }
+              break;
+            }
           }
-          this.polylineOption.push(polylineOptions)
+          if (!flagLine) {
+            let polylineOptions = new PolylineOptions();
+            this.polyLineTag.push(this.ctx.descriptorRegistry.getDescriptor(descriptor.childrenTags[i]).tag);
+            GlobalCache.currentPagePolyline.set(this.ctx.descriptorRegistry.getDescriptor(descriptor.childrenTags[i])
+              .tag,
+              this.tag)
+            if (this.aMap) {
+              try {
+                let polylineOptionsList = new ArrayList<LatLng>()
+                for (let index = 0; index < mapPolylineProp.points.length; index++) {
+                  polylineOptionsList.add(new LatLng(mapPolylineProp.points[index].latitude,
+                    mapPolylineProp.points[index].longitude))
+                }
+                if (mapPolylineProp.colors) {
+                  let test = new Int32Array(mapPolylineProp.colors.length)
+                  for (let i = 0; i < mapPolylineProp.colors.length; ++i) {
+                    let str = mapPolylineProp.colors[i].replace("#", "0xff")
+                    test[i] = parseInt(str.substring(2, str.length), 16)
+                  }
+                  let polyline = this.aMap?.addPolyline(polylineOptions
+                    .setColorValues(test)
+                    .setGradient(mapPolylineProp.gradient ? mapPolylineProp.gradient : false)
+                    .setZIndex(mapPolylineProp.zIndex ? mapPolylineProp.zIndex : 1)
+                    .setDottedLine(mapPolylineProp.dotted ? mapPolylineProp.dotted : false)
+                    .setGeodesic(mapPolylineProp.geodesic ? mapPolylineProp.geodesic : false)
+                    .setWidth(mapPolylineProp.width ? mapPolylineProp.width : 5)
+                    .setGradient(mapPolylineProp.gradient ? mapPolylineProp.gradient : false));
+                  if (polyline) {
+                    polyline.setPoints(polylineOptionsList);
+                    GlobalCache.polyLines.push(polyline);
+                  }
+                } else if (mapPolylineProp.color) {
+                  let polyline = this.aMap?.addPolyline(polylineOptions
+                    .setColor(rgbaToHex(mapPolylineProp.color ? mapPolylineProp.color :
+                      "rgba(0, 255, 0, 0.5)"))
+                    .setGradient(mapPolylineProp.gradient ? mapPolylineProp.gradient : false)
+                    .setZIndex(mapPolylineProp.zIndex ? mapPolylineProp.zIndex : 1)
+                    .setDottedLine(mapPolylineProp.dotted ? mapPolylineProp.dotted : false)
+                    .setGeodesic(mapPolylineProp.geodesic ? mapPolylineProp.geodesic : false)
+                    .setWidth(mapPolylineProp.width ? mapPolylineProp.width : 5)
+                    .setGradient(mapPolylineProp.gradient ? mapPolylineProp.gradient : false));
+                  if (polyline) {
+                    polyline.setPoints(polylineOptionsList);
+                    GlobalCache.polyLines.push(polyline);
+                  }
+                }
+                GlobalCache.mapPolyLine.set(this.tag, GlobalCache.polyLines);
+              } catch (error) {
+                Logger.error('mapPolylineProp---------Error adding polyline:', error);
+              }
+            }
+          }
           break;
         case A_MAP_MARKER_TYPE:
           let mapMarkerProps =
             this.ctx.descriptorRegistry.getDescriptor(descriptor.childrenTags[i]).props as AMapMarkerProps;
-          for (let i = 0; i < (mapMarker.get(AMapView.num) ?? []).length; ++i) { //遍历数组里是否有之前的经纬度 没有在新增  修改
-            let marker = (mapMarker.get(AMapView.num) ?? []);
-            if ((mapMarkerProps.position.latitude == marker[i].getPosition().latitude)
-              && (mapMarkerProps.position.longitude == marker[i].getPosition().longitude)) {
+          let marker = (GlobalCache.mapMarker.get(this.tag) ?? []);
+          for (let i = 0; i < (GlobalCache.mapMarker.get(this.tag) ?? []).length; ++i) {
+            if ((mapMarkerProps.position.latitude == marker[i].getPosition().latitude) &&
+              (mapMarkerProps.position.longitude == marker[i].getPosition().longitude)) {
               flag = true;
               marker[i].setAnchor(mapMarkerProps.anchor ? mapMarkerProps.anchor.x : 1,
                 mapMarkerProps.anchor ? mapMarkerProps.anchor.y : 0.5);
               marker[i].setDraggable(mapMarkerProps.draggable ? mapMarkerProps.draggable : false);
               marker[i].setZIndex(mapMarkerProps.zIndex ? mapMarkerProps.zIndex : 1);
               marker[i].setFlat(mapMarkerProps.flat ? mapMarkerProps.flat : false);
+              marker[i].getOptions().setInfoWindowOffset(mapMarkerProps.centerOffset?.x,mapMarkerProps.centerOffset?.y);
+              marker[i].setMarkerOptions(marker[i].getOptions());
               if (mapMarkerProps.icon) {
                 try {
                   let resoure: string = mapMarkerProps.icon["uri"];
@@ -537,67 +585,54 @@ export struct AMapView {
           }
           if (!flag) {
             let markerOptions = new MarkerOptions();
+            GlobalCache.currentPageMarker.set(this.ctx.descriptorRegistry.getDescriptor(descriptor.childrenTags[i]).tag,
+              this.tag)
             this.markerTag.push(this.ctx.descriptorRegistry.getDescriptor(descriptor.childrenTags[i]).tag);
-            if (!this.aMap) {
-            } else {
+            if (this.aMap) {
               try {
                 let marker = this.aMap.addMarker(markerOptions);
-                if (!marker) {
-                  console.error('mapMarkerProps---------Failed to add marker. Check markerOptions:', markerOptions);
-                } else {
-                  if (marker) {
-                    markers.push(marker);
-                    marker.setPosition(new LatLng(mapMarkerProps.position.latitude,
-                      mapMarkerProps.position.longitude));
-                    marker.setAnchor(mapMarkerProps.anchor ? mapMarkerProps.anchor.x : 1,
-                      mapMarkerProps.anchor ? mapMarkerProps.anchor.y : 0.5);
-                    if (mapMarkerProps.icon) {
-                      try {
-                        let resoure: string = mapMarkerProps.icon["uri"];
-                        let bitmapDes: BitmapDescriptor | undefined =
-                          await BitmapDescriptorFactory.fromRawfilePath(globalContext, resoure);
-                        marker.setIcon(bitmapDes);
-                      } catch (error) {
-                        let bitmapDesNull: BitmapDescriptor | undefined =
-                          await BitmapDescriptorFactory.fromRawfilePath(globalContext, "common/marker_default.png");
-                        if (bitmapDesNull) {
-                          marker.setIcon(bitmapDesNull);
-                        }
+                if (marker) {
+                  GlobalCache.markers.push(marker);
+                  marker.setPosition(new LatLng(mapMarkerProps.position.latitude,
+                    mapMarkerProps.position.longitude));
+                  marker.setAnchor(mapMarkerProps.anchor ? mapMarkerProps.anchor.x : 1,
+                    mapMarkerProps.anchor ? mapMarkerProps.anchor.y : 0.5);
+                  if (mapMarkerProps.icon) {
+                    try {
+                      let resoure: string = mapMarkerProps.icon["uri"];
+                      let bitmapDes: BitmapDescriptor | undefined =
+                        await BitmapDescriptorFactory.fromRawfilePath(globalContext, resoure);
+                      marker.setIcon(bitmapDes);
+                    } catch (error) {
+                      let bitmapDesNull: BitmapDescriptor | undefined =
+                        await BitmapDescriptorFactory.fromRawfilePath(globalContext, "common/marker_default.png");
+                      if (bitmapDesNull) {
+                        marker.setIcon(bitmapDesNull);
                       }
                     }
-                    marker.setDraggable(mapMarkerProps.draggable ? mapMarkerProps.draggable : false);
-                    marker.setZIndex(mapMarkerProps.zIndex ? mapMarkerProps.zIndex : 1);
-                    marker.setFlat(mapMarkerProps.flat ? mapMarkerProps.flat : false);
-                    mapMarker.set(AMapView.num, markers);
                   }
+                  marker.setDraggable(mapMarkerProps.draggable ? mapMarkerProps.draggable : false);
+                  marker.setZIndex(mapMarkerProps.zIndex ? mapMarkerProps.zIndex : 1);
+                  marker.setFlat(mapMarkerProps.flat ? mapMarkerProps.flat : false);
+                  marker.getOptions().setInfoWindowOffset(mapMarkerProps.centerOffset?.x,mapMarkerProps.centerOffset?.y);
+                  marker.setMarkerOptions(marker.getOptions());
+                  GlobalCache.mapMarker.set(this.tag, GlobalCache.markers);
                 }
               } catch (error) {
-                console.error('mapMarkerProps---------Error adding marker:', error);
+                Logger.error('mapMarkerProps---------Error adding marker:', error);
               }
             }
           }
           break;
       }
       flag = false;
+      flagLine = false;
     }
-  }
-
-  aboutToDisappear(): void {
-    if (this.mapViewCreateCallback) {
-      MapViewManager.getInstance().unregisterMapViewCreatedCallback(this.mapViewCreateCallback);
-    }
-    if (this.mapView) {
-      this.mapView.onDestroy();
-      this.mapView = undefined;
-      this.aMap = undefined;
-    }
-    mapMarker.delete(AMapView.num);
-    AMapView.num -= 1;
   }
 
   build() {
     RNViewBase({ ctx: this.ctx, tag: this.tag }) {
-      MapViewComponent().width('100%').height('100%')
+      MapViewComponent({ mapViewName: new String(this.tag).valueOf() }).width('100%').height('100%')
     }
   }
 }


### PR DESCRIPTION
# Summary
fix: 修改跳转3级及以上界面返回时地图为空的情况，修改覆盖物创建方式
## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)
