### PR TITLE
feat:支持地图覆盖物颜色的十六进制表示

### DIFF
--- a/harmony/rn_amap3d/src/main/ets/View/AMapCircle.ets
+++ b/harmony/rn_amap3d/src/main/ets/View/AMapCircle.ets
@@ -2,15 +2,50 @@ import { LatLng} from '@amap/amap_lbs_map3d'
 import { Descriptor, RNOHContext, ViewBaseProps } from '@rnoh/react-native-openharmony';
 
 export function rgbaToHex(rgbaString: string): number {
-  const match = rgbaString.match(/(\d+(\.\d+)?)/g);
-  if (match && match.length >= 4) {
-    const alpha = Math.round(parseFloat(match[3]) * 255); // 将 alpha 值转换为 0-255 范围内的整数
+  // 处理十六进制字符串（如 #RGB、#RRGGBB、#AARRGGBB）
+  let value: number;
+  if (rgbaString.startsWith('#')) {
+    const hex = rgbaString.slice(1); // 去掉 #
+    // 根据长度解析十六进制
+    switch (hex.length) {
+      case 3: // #RGB → 转换为 #RRGGBB（Alpha=FF）
+        value = parseInt(hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2], 16);
+        return 0xFF000000 | value;
+      case 6: // #RRGGBB → 转换为 #AARRGGBB（Alpha=FF）
+        value = parseInt(hex, 16);
+        return 0xFF000000 | value;
+      case 8: // #AARRGGBB → 直接转换为数值
+        return parseInt(hex, 16);
+      default:
+        throw new Error('Invalid hex color format (expected #RGB, #RRGGBB, or #AARRGGBB)');
+    }
+  }
+
+  // 处理 RGB 格式（无 Alpha）
+  if (rgbaString.startsWith('rgb(')) {
+    const match = rgbaString.match(/(\d+(\.\d+)?)/g);
+    if (!match) throw new Error('Invalid RGB string format');
     const red = parseInt(match[0]);
     const green = parseInt(match[1]);
     const blue = parseInt(match[2]);
-    return (alpha << 24) | (red << 16) | (green << 8) | blue;
-  } else {
-    throw new Error('Invalid RGBA string format');
+    value = 0xFF000000 | (red << 16) | (green << 8) | blue;
+    return value;
+  }
+
+  // 处理 RGBA 格式
+  if (rgbaString.startsWith('rgba(')) {
+    const match = rgbaString.match(/(\d+(\.\d+)?)/g);
+    if (!match) throw new Error('Invalid RGBA string format');
+    const r = match[0];
+    const g = match[1];
+    const b = match[2];
+    const a = match[3];
+    const red = Math.min(255, Math.max(0, parseInt(r)));
+    const green = Math.min(255, Math.max(0, parseInt(g)));
+    const blue = Math.min(255, Math.max(0, parseInt(b)));
+    const alpha = Math.round(Math.min(1, Math.max(0, parseFloat(a))) * 255);
+    value = (alpha << 24) | (red << 16) | (green << 8) | blue;
+    return value;
   }
 }
 
@@ -31,7 +66,6 @@ export struct AMapCircle {
   static NAME:string = "AMapCircle";
   ctx!: RNOHContext
   tag: number = -1
-  // @State gDMapDescriptor: GDMapViewDescriptor = {} as GDMapViewDescriptor
   build() {
   }
 }


### PR DESCRIPTION
# Summary

- feat:扩展地图覆盖物颜色的输入形式，兼容rgb()，rgba()，十六进制数（包含#123，#112233，#00112233的表示形式）

## Test Plan
<img width="1555" height="336" alt="image" src="https://github.com/user-attachments/assets/32cdf72a-4eaa-47f0-9bab-0ec282e17556" />
<img width="688" height="1008" alt="image" src="https://github.com/user-attachments/assets/7179bbb0-8564-404b-9df5-41f0493c42a4" />


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)
