### PR TITLE
fix:修复polyline设置同样的宽度比android细很多的问题

### DIFF
--- a/harmony/rn_amap3d/src/main/ets/View/AMapPolyline.ets
+++ b/harmony/rn_amap3d/src/main/ets/View/AMapPolyline.ets
@@ -53,7 +53,7 @@ export struct AMapPolyline {
                     this.polyLines[i].setZIndex(mapPolylineProp.zIndex ? mapPolylineProp.zIndex : 1);
                     this.polyLines[i].setDottedLine(mapPolylineProp.dotted ? mapPolylineProp.dotted : false);
                     this.polyLines[i].setGeodesic(mapPolylineProp.geodesic ? mapPolylineProp.geodesic : false);
-                    this.polyLines[i].setWidth(mapPolylineProp.width ? mapPolylineProp.width : 5);
+                    this.polyLines[i].setWidth(mapPolylineProp.width ? vp2px(mapPolylineProp.width) : vp2px(5));
                     let polylineOptionsList = new ArrayList<LatLng>()
                     for (let index = 0; index < mapPolylineProp.points.length; index++) {
                       polylineOptionsList.add(new LatLng(mapPolylineProp.points[index].latitude,

--- a/harmony/rn_amap3d/src/main/ets/View/MapView.ets
+++ b/harmony/rn_amap3d/src/main/ets/View/MapView.ets
@@ -503,7 +503,7 @@ export struct AMapView {
                     GlobalCachePolyLines[polylineIndex].setZIndex(mapPolylineProp.zIndex ? mapPolylineProp.zIndex : 1);
                     GlobalCachePolyLines[polylineIndex].setDottedLine(mapPolylineProp.dotted ? mapPolylineProp.dotted : false);
                     GlobalCachePolyLines[polylineIndex].setGeodesic(mapPolylineProp.geodesic ? mapPolylineProp.geodesic : false);
-                    GlobalCachePolyLines[polylineIndex].setWidth(mapPolylineProp.width ? mapPolylineProp.width : 5);
+                    GlobalCachePolyLines[polylineIndex].setWidth(mapPolylineProp.width ? vp2px(mapPolylineProp.width) : vp2px(5));
                     if (mapPolylineProp.color) {
                       GlobalCachePolyLines[polylineIndex].setColor(rgbaToHex(mapPolylineProp.color ? mapPolylineProp.color :
                         "rgba(0, 255, 0, 0.5)"));
@@ -548,7 +548,7 @@ export struct AMapView {
                     .setZIndex(mapPolylineProp.zIndex ? mapPolylineProp.zIndex : 1)
                     .setDottedLine(mapPolylineProp.dotted ? mapPolylineProp.dotted : false)
                     .setGeodesic(mapPolylineProp.geodesic ? mapPolylineProp.geodesic : false)
-                    .setWidth(mapPolylineProp.width ? mapPolylineProp.width : 5)
+                    .setWidth(mapPolylineProp.width ? vp2px(mapPolylineProp.width) : vp2px(5))
                     .setGradient(mapPolylineProp.gradient ? mapPolylineProp.gradient : false));
                 if(polyline){
                   polyline.setPoints(polylineOptionsList);


### PR DESCRIPTION
[fix:修复polyline设置同样的宽度比android细很多的问题](https://github.com/react-native-oh-library/react-native-amap3d/commit/cb37916c9d32d6ea008ddc0dd21e9fe24f8af23f)

# Summary

- 修复polyline设置同样的宽度比android细很多的问题


## Test Plan

鸿蒙效果，设置polyline的宽度为100
<img width="650" height="1387" alt="image" src="https://github.com/user-attachments/assets/196afab4-831c-4c12-a090-7276a12a4e53" />
android效果，设置的polyline的宽度同样为100
<img width="1506" height="2007" alt="image" src="https://github.com/user-attachments/assets/0c946acf-eb53-4d1c-b1eb-5518e3a8cea3" />



## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)

