### PR TITLE
fix: react-native-amap3d属性zIndex无效问题

### DIFF
--- a/harmony/rn_amap3d/src/main/ets/View/MapView.ets
+++ b/harmony/rn_amap3d/src/main/ets/View/MapView.ets
@@ -463,6 +463,7 @@ export struct AMapView {
             circle.setStrokeColor(rgbaToHex(circleProp.strokeColor ? circleProp.strokeColor :
               "rgba(0, 0, 255, 0.5)"));
             circle.setStrokeWidth(circleProp.strokeWidth ? circleProp.strokeWidth : 5);
+			circle.setZIndex(circleProp.zIndex ? circleProp.zIndex : 2);
           }
           break;
         case A_MAP_POLYGON_TYPE:


### PR DESCRIPTION
# Summary
1： fix: react-native-amap3d属性zIndex无效问题

## Test Plan
![amap3d](https://github.com/user-attachments/assets/5ad4baa6-c310-4528-bed0-7f8334f0d02e)


## Checklist
- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
