### PR TITLE
fix: react-native-amap3d属性zIndex无效问题

### DIFF
--- a/harmony/rn_amap3d/src/main/ets/View/MapView.ets
+++ b/harmony/rn_amap3d/src/main/ets/View/MapView.ets
@@ -494,6 +494,7 @@ export struct AMapView {
             circle.setStrokeColor(rgbaToHex(circleProp.strokeColor ? circleProp.strokeColor :
               "rgba(0, 0, 255, 0.5)"));
             circle.setStrokeWidth(circleProp.strokeWidth ? circleProp.strokeWidth : 5);
+	    circle.setZIndex(circleProp.zIndex ? circleProp.zIndex : 2);
           }
           break;
         case A_MAP_POLYGON_TYPE:


### PR DESCRIPTION
fix: react-native-amap3d属性zIndex无效问题